### PR TITLE
Add cheapbastards to free subdomain directory

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import Card from '~/components/Card.astro'
 		<Header />
 		<section>
 			<ul role="list">
+				<Card title="cheapbastards" href="https://cheapbastards.xyz" body="Free subdomains with delegated DNS or managed records." />
 				<Card title="cluster.ws" href="https://cluster.ws" repo="https://github.com/Olivr/free-domain" />
 				<Card title="is-an.app" href="https://is-an.app" repo="https://github.com/tarampampam/free-domains" />
 				<Card title="is-a.dev" href="https://is-a.dev" repo="https://github.com/is-a-dev/register" />


### PR DESCRIPTION
Adds [cheapbastards](https://cheapbastards.xyz) to the free subdomain directory.

**About cheapbastards:**
- Free subdomain registry with delegated DNS (bring your own nameservers) or managed records
- GitHub OAuth auth
- HTTPS verification for managed records
- Abuse handling and cooldown policies